### PR TITLE
Allow swiping to progress to the next coachmark

### DIFF
--- a/Coach Marks/DDCoachMarksView.m
+++ b/Coach Marks/DDCoachMarksView.m
@@ -75,7 +75,8 @@ static const CGFloat    kLblSpacing = 35.0f;
 
     // Capture touches
     UITapGestureRecognizer *tapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(userDidTap:)];
-    UISwipeGestureRecognizer *swipeGestureRecognizer = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:nil];
+    UISwipeGestureRecognizer *swipeGestureRecognizer = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(userDidTap:)];
+    swipeGestureRecognizer.direction = UISwipeGestureRecognizerDirectionLeft | UISwipeGestureRecognizerDirectionRight;
     [self addGestureRecognizer:swipeGestureRecognizer];
     [self addGestureRecognizer:tapGestureRecognizer];
     


### PR DESCRIPTION
Make it so that people can swipe to progress to the next coachmark - especially important when the coachmark is itself a swipe gesture (it's REALLY confusing to see a swipe action indicated but then not be able to swipe)
