### PR TITLE
Swift support via obj-c bridging header

### DIFF
--- a/Coach Marks-Bridging-Header.h
+++ b/Coach Marks-Bridging-Header.h
@@ -1,0 +1,3 @@
+#import "DDCoachMarksView.h"
+#import "DDBubble.h"
+#import "DDCircleView.h"

--- a/Coach Marks.xcodeproj/project.pbxproj
+++ b/Coach Marks.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		935EE4C118F07520001F039E /* DDCircleView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDCircleView.m; sourceTree = "<group>"; };
 		935EE4C218F07520001F039E /* DDCoachMarksView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDCoachMarksView.h; sourceTree = "<group>"; };
 		935EE4C318F07520001F039E /* DDCoachMarksView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDCoachMarksView.m; sourceTree = "<group>"; };
+		D77D5BFE1ED5C364009CFE31 /* Coach Marks-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Coach Marks-Bridging-Header.h"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -95,6 +96,7 @@
 				93299DC718EBEA2700D8E660 /* Coach MarksTests */,
 				93299DA118EBEA2600D8E660 /* Frameworks */,
 				93299DA018EBEA2600D8E660 /* Products */,
+				D77D5BFE1ED5C364009CFE31 /* Coach Marks-Bridging-Header.h */,
 			);
 			sourceTree = "<group>";
 		};
@@ -211,9 +213,12 @@
 		93299D9718EBEA2600D8E660 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0510;
+				LastUpgradeCheck = 0820;
 				ORGANIZATIONNAME = "Darin Doria";
 				TargetAttributes = {
+					93299D9E18EBEA2600D8E660 = {
+						LastSwiftMigration = 0820;
+					};
 					93299DBF18EBEA2700D8E660 = {
 						TestTargetID = 93299D9E18EBEA2600D8E660;
 					};
@@ -394,10 +399,15 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				CLANG_ENABLE_MODULES = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Coach Marks/Coach Marks-Prefix.pch";
 				INFOPLIST_FILE = "Coach Marks/Coach Marks-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "Coach Marks-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -407,10 +417,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				CLANG_ENABLE_MODULES = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Coach Marks/Coach Marks-Prefix.pch";
 				INFOPLIST_FILE = "Coach Marks/Coach Marks-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "Coach Marks-Bridging-Header.h";
+				SWIFT_VERSION = 3.0;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;


### PR DESCRIPTION
## What is this
DDBubble, DDCircleView, and DDCoachMarksView were inaccessible from Swift files.

## What i did
Created an Objective-C bridging header that allows DDBubble, DDCircleView, and DDCoachMarksView to be used in Swift

## Example

```swift
let coachMarks = [
            [
                "rect": someButton.frame,
                "caption": "Synchronize your mail",
                "font": UIFont.boldSystemFont(ofSize: 14.0),
                "shape": "circle"
            ],
            [
                "rect": anotherButton.frame,
                "caption": "Create a new message",
                "font": UIFont.boldSystemFont(ofSize: 14.0)
            ],
        ]
        
let coachmarksView = DDCoachMarksView(frame: view.bounds, coachMarks: coachMarks)
view.addSubview(coachmarksView!)
coachmarksView!.start()
```